### PR TITLE
Fix chapter 1 build issues.

### DIFF
--- a/boot.properties
+++ b/boot.properties
@@ -1,0 +1,5 @@
+#http://boot-clj.com
+#Fri Mar 17 10:02:38 PDT 2017
+BOOT_CLOJURE_NAME=org.clojure/clojure
+BOOT_CLOJURE_VERSION=1.9.0-alpha12
+BOOT_VERSION=2.7.1

--- a/build.boot
+++ b/build.boot
@@ -1,8 +1,7 @@
 (set-env!
   :source-paths #{"src/frontend"
                   "src/backend"
-                  "src/cross"
-                  "src/dev-backend"}
+                  "src/cross"}
   :resource-paths #{"resources"}
   :dependencies '[[org.clojure/clojure "1.9.0-alpha12"]
                   [org.clojure/clojurescript "1.9.456"]

--- a/infrastructure/deploy
+++ b/infrastructure/deploy
@@ -1,4 +1,5 @@
 #!/bin/bash
+mkdir -p ansible/files
 cp ../target/build/app.jar ansible/files/app.jar
 cd ansible
 ansible-playbook -i inventories/$1 sweet-tooth.yml --skip-tags=install


### PR DESCRIPTION
- Remove `src/dev-backend` from build.boot. It doesn't appear to be
  used, and having it there causes boot to bail out.
- Add a boot.properties file specifying the version of Clojure to use to
  avoid a classpath error while building. Boot defaults to 1.7.0
  otherwise.
- Ensure `infrastructure/ansible/files` exists before trying to copy
  files into it.